### PR TITLE
Rename, add project and config description

### DIFF
--- a/Rust.novaextension/extension.json
+++ b/Rust.novaextension/extension.json
@@ -1,8 +1,8 @@
 {
   "identifier": "com.kilb.Rust",
-  "name": "Rust",
+  "name": "Rust Analyzer",
   "organization": "Drew Kilb",
-  "description": "Lorem ipsum, dolor sit amet.",
+  "description": "Rust support for Nova with Rust Analyzer",
   "version": "1.0",
   "categories": ["languages"],
 
@@ -16,9 +16,11 @@
   "config": [
     {
       "key": "com.kilb.rust.language-server-path",
-      "title": "Language Server Path",
+      "title": "Rust Analyzer Path",
+      "description": "Path to the Rust Analyzer binary",
+      "link": "https://github.com/rust-analyzer/rust-analyzer/releases",
       "type": "path",
-      "placeholder": "/usr/local/bin/example"
+      "required": true
     }
   ]
 }

--- a/Rust.novaextension/extension.json
+++ b/Rust.novaextension/extension.json
@@ -6,7 +6,14 @@
   "version": "1.0",
   "categories": ["languages"],
 
+  "repository": "https://github.com/kilbd/nova-rust",
+  "bugs": "https://github.com/kilbd/nova-rust/issues",
+
   "main": "main.js",
+
+  "activationEvents": [
+    "onWorkspaceContains:Cargo.toml"
+  ],
 
   "entitlements": {
     "process": true,


### PR DESCRIPTION
Renamed because there’s already an extension named Rust for RLS