### PR TITLE
Task template for Cargo commands

### DIFF
--- a/Rust.novaextension/extension.json
+++ b/Rust.novaextension/extension.json
@@ -90,6 +90,18 @@
           "type": "string"
         }
       ]
+    },
+    {
+      "title": "Environment",
+      "type": "section",
+      "children": [
+        {
+          "key": "com.kilb.rust.env-vars",
+          "title": "Environment Variables",
+          "description": "These values are passed to Rust Analyzer and tasks created with the Cargo template. Each entry should have the format VARIABLENAME=somevalue. Values here will apply to any Rust project, and are useful for global settings like RUST_BACKTRACE=1.",
+          "type": "stringArray"
+        }
+      ]
     }
   ],
   "configWorkspace": [
@@ -115,6 +127,18 @@
           "title": "Additional Arguments",
           "description": "Arguments to pass to the Cargo lint command you selected.",
           "type": "string"
+        }
+      ]
+    },
+    {
+      "title": "Environment",
+      "type": "section",
+      "children": [
+        {
+          "key": "com.kilb.rust.env-vars",
+          "title": "Environment Variables",
+          "description": "These values are passed to Rust Analyzer and tasks created with the Cargo template. Each entry should have the format VARIABLENAME=somevalue. Values here will apply only to this project and can override global settings. A useful example is setting DATABASE_URL which is required by the sqlx::query macro.",
+          "type": "stringArray"
         }
       ]
     }

--- a/Rust.novaextension/extension.json
+++ b/Rust.novaextension/extension.json
@@ -120,21 +120,51 @@
     }
   ],
   "taskTemplates": {
-    "cargo-test": {
-      "name": "Cargo Test",
-      "description": "Runs tests with `cargo test`",
+    "cargo": {
+      "name": "Cargo",
+      "description": "Easily set up common Cargo commands.",
       "tasks": {
+        "build": {
+          "resolve": "com.kilb.rust.assistants.cargo"
+        },
         "run": {
+          "resolve": "com.kilb.rust.assistants.cargo"
+        },
+        "clean": {
           "shell": true,
           "command": "cargo",
-          "args": ["test", "$(Config:com.kilb.rust.cargo-test.args)"]
+          "args": ["clean"]
         }
       },
       "config": [
         {
-          "key": "com.kilb.rust.cargo-test.args",
+          "key": "com.kilb.rust.cargo.build.subcommand",
+          "title": "Build Subcommand",
+          "description": "The Cargo command to run for Build task.",
+          "type": "enum",
+          "values": ["build", "test", "bench"],
+          "default": "build",
+          "radio": true
+        },
+        {
+          "key": "com.kilb.rust.cargo.build.args",
           "title": "Additional Arguments",
-          "description": "Arguments to pass to `cargo test`.",
+          "description": "Arguments to pass to the selected Cargo command for Build task.",
+          "type": "string"
+        },
+        {
+          "key": "com.kilb.rust.cargo.run.subcommand",
+          "title": "Run Subcommand",
+          "description": "The Cargo command to run for Run task.",
+          "type": "enum",
+          "values": ["run", "test", "bench"],
+          "default": "run",
+          "radio": true
+        },
+        {
+          "key": "com.kilb.rust.cargo.run.args",
+          "title": "Additional Arguments",
+          "description": "Arguments to pass to the selected Cargo command for Run task.",
           "type": "string"
         }
       ]

--- a/Rust.novaextension/extension.json
+++ b/Rust.novaextension/extension.json
@@ -118,5 +118,26 @@
         }
       ]
     }
-  ]
+  ],
+  "taskTemplates": {
+    "cargo-test": {
+      "name": "Cargo Test",
+      "description": "Runs tests with `cargo test`",
+      "tasks": {
+        "run": {
+          "shell": true,
+          "command": "cargo",
+          "args": ["test", "$(Config:com.kilb.rust.cargo-test.args)"]
+        }
+      },
+      "config": [
+        {
+          "key": "com.kilb.rust.cargo-test.args",
+          "title": "Additional Arguments",
+          "description": "Arguments to pass to `cargo test`.",
+          "type": "string"
+        }
+      ]
+    }
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
-  "name": "nova-npm",
-  "version": "0.1.0",
+  "name": "nova-rust",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "nova-npm",
-      "version": "0.1.0",
+      "name": "nova-rust",
+      "version": "2.1.0",
       "devDependencies": {
         "@types/jest": "^27.0.2",
-        "@types/nova-editor-node": "^4.1.3",
+        "@types/nova-editor-node": "^4.1.5",
         "jest": "^27.2.2",
         "prettier": "^2.4.1",
         "ts-jest": "^27.0.5",
-        "typescript": "^4.4.3"
+        "typescript": "^4.8.4"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -985,9 +985,9 @@
       "dev": true
     },
     "node_modules/@types/nova-editor-node": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@types/nova-editor-node/-/nova-editor-node-4.1.3.tgz",
-      "integrity": "sha512-MDwY3qAv0HVFEP1uE8Ku6RjMmLW2Acl/EvDjxUofbLkvFup3sdZW+uVFLRtMCpZwTn/qu6Yc1hDIdjVytvfokQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@types/nova-editor-node/-/nova-editor-node-4.1.5.tgz",
+      "integrity": "sha512-oq3Bobk00wmy4ahoDEcICGUzLxw8eaUN7Th0xNyH2wFl6eL6S9ZX+I09t2Y4ZYKEiztiDwf0TM1r12zkigyKRw==",
       "dev": true
     },
     "node_modules/@types/prettier": {
@@ -3836,9 +3836,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
-      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -4853,9 +4853,9 @@
       "dev": true
     },
     "@types/nova-editor-node": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@types/nova-editor-node/-/nova-editor-node-4.1.3.tgz",
-      "integrity": "sha512-MDwY3qAv0HVFEP1uE8Ku6RjMmLW2Acl/EvDjxUofbLkvFup3sdZW+uVFLRtMCpZwTn/qu6Yc1hDIdjVytvfokQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@types/nova-editor-node/-/nova-editor-node-4.1.5.tgz",
+      "integrity": "sha512-oq3Bobk00wmy4ahoDEcICGUzLxw8eaUN7Th0xNyH2wFl6eL6S9ZX+I09t2Y4ZYKEiztiDwf0TM1r12zkigyKRw==",
       "dev": true
     },
     "@types/prettier": {
@@ -7017,9 +7017,9 @@
       }
     },
     "typescript": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
-      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "dev": true
     },
     "universalify": {

--- a/package.json
+++ b/package.json
@@ -9,11 +9,11 @@
   },
   "devDependencies": {
     "@types/jest": "^27.0.2",
-    "@types/nova-editor-node": "^4.1.3",
+    "@types/nova-editor-node": "^4.1.5",
     "jest": "^27.2.2",
     "prettier": "^2.4.1",
     "ts-jest": "^27.0.5",
-    "typescript": "^4.4.3"
+    "typescript": "^4.8.4"
   },
   "prettier": {
     "semi": false,

--- a/src/cargo-task-assistant.ts
+++ b/src/cargo-task-assistant.ts
@@ -1,14 +1,35 @@
+import { envVarObject, onPreferenceChange } from './preference-resolver'
+
 class CargoTaskAssistant {
+  private envVars: Object = {}
+
+  constructor() {
+    onPreferenceChange('com.kilb.rust.env-vars', true, (varList: string[]) => {
+      this.envVars = envVarObject(varList)
+    })
+  }
+
   // Required, but unused, method. Tasks are configured in extension.json.
   provideTasks(): AssistantArray<Task> {
     return []
   }
 
   resolveTaskAction(context: TaskActionResolveContext<any>): TaskProcessAction {
-    console.log(context.config)
+    let args: string[] = []
+    let cmdPref = 'com.kilb.rust.cargo.build.subcommand'
+    let argPref = 'com.kilb.rust.cargo.build.args'
+    if (context.action === Task.Run) {
+      cmdPref = 'com.kilb.rust.cargo.run.subcommand'
+      argPref = 'com.kilb.rust.cargo.run.args'
+    }
+    args.push(context.config?.get(cmdPref) as string)
+    let comArgs = context.config?.get(argPref)
+    if (comArgs) args.push(comArgs as string)
+
     return new TaskProcessAction('cargo', {
       shell: true,
-      args: ['build'],
+      args: args,
+      env: this.envVars as { [key: string]: string },
     })
   }
 }

--- a/src/cargo-task-assistant.ts
+++ b/src/cargo-task-assistant.ts
@@ -1,4 +1,8 @@
-import { envVarObject, onPreferenceChange } from './preference-resolver'
+import {
+  envVarObject,
+  onPreferenceChange,
+  splitArgString,
+} from './preference-resolver'
 
 class CargoTaskAssistant {
   private envVars: Object = {}
@@ -24,7 +28,9 @@ class CargoTaskAssistant {
     }
     args.push(context.config?.get(cmdPref) as string)
     let comArgs = context.config?.get(argPref)
-    if (comArgs) args.push(comArgs as string)
+    console.log(comArgs)
+    if (comArgs) args = args.concat(splitArgString(comArgs as string))
+    console.log(args)
 
     return new TaskProcessAction('cargo', {
       shell: true,

--- a/src/cargo-task-assistant.ts
+++ b/src/cargo-task-assistant.ts
@@ -1,0 +1,16 @@
+class CargoTaskAssistant {
+  // Required, but unused, method. Tasks are configured in extension.json.
+  provideTasks(): AssistantArray<Task> {
+    return []
+  }
+
+  resolveTaskAction(context: TaskActionResolveContext<any>): TaskProcessAction {
+    console.log(context.config)
+    return new TaskProcessAction('cargo', {
+      shell: true,
+      args: ['build'],
+    })
+  }
+}
+
+export { CargoTaskAssistant }

--- a/src/main.ts
+++ b/src/main.ts
@@ -42,7 +42,7 @@ export async function activate() {
   )
   nova.commands.register('com.kilb.rust.restart', () => langServer?.restart())
   nova.assistants.registerTaskAssistant(cargoTasks, {
-    identifer: 'com.kilb.rust.assistants.cargo',
+    identifier: 'com.kilb.rust.assistants.cargo',
     name: 'Cargo',
   })
   nova.fs.watch('**/Cargo.toml', () => langServer?.restart())

--- a/src/main.ts
+++ b/src/main.ts
@@ -39,6 +39,8 @@ export async function activate() {
     rename(editor, langServer)
   )
   nova.commands.register('com.kilb.rust.restart', () => langServer?.restart())
+  nova.fs.watch('**/Cargo.toml', () => langServer?.restart())
+  nova.fs.watch('**/rust-project.json', () => langServer?.restart())
 }
 
 export function deactivate() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,4 @@
+import { CargoTaskAssistant } from './cargo-task-assistant'
 import { RustFormatter } from './rust-formatter'
 import { RustLanguageServer } from './rust-lang-server'
 import {
@@ -13,6 +14,7 @@ export async function activate() {
   // Do work when the extension is activated
   langServer = new RustLanguageServer()
   let formatter = new RustFormatter()
+  let cargoTasks = new CargoTaskAssistant()
   nova.workspace.onDidAddTextEditor(async (editor: TextEditor) => {
     editor.onWillSave((editor: TextEditor) => {
       return formatter.format(editor)
@@ -39,6 +41,10 @@ export async function activate() {
     rename(editor, langServer)
   )
   nova.commands.register('com.kilb.rust.restart', () => langServer?.restart())
+  nova.assistants.registerTaskAssistant(cargoTasks, {
+    identifer: 'com.kilb.rust.assistants.cargo',
+    name: 'Cargo',
+  })
   nova.fs.watch('**/Cargo.toml', () => langServer?.restart())
   nova.fs.watch('**/rust-project.json', () => langServer?.restart())
 }

--- a/src/preference-resolver.ts
+++ b/src/preference-resolver.ts
@@ -1,5 +1,5 @@
 // Function to reconcile global and local preferences
-export function onPreferenceChange(
+function onPreferenceChange(
   name: string,
   append: boolean,
   callback: (value: any) => void
@@ -25,3 +25,20 @@ export function onPreferenceChange(
     }
   })
 }
+
+// Takes the string array of combined environment variable preferences, and returns
+// an object that can be given to processes.
+function envVarObject(envs: string[]): Object {
+  let map = new Map()
+  envs.forEach((e) => {
+    let env = e.trim()
+    let splitIndex = env.indexOf('=')
+    map.set(
+      env.substring(0, splitIndex).trim(),
+      env.substring(splitIndex + 1).trim()
+    )
+  })
+  return Object.fromEntries(map)
+}
+
+export { onPreferenceChange, envVarObject }

--- a/src/preference-resolver.ts
+++ b/src/preference-resolver.ts
@@ -31,12 +31,16 @@ function onPreferenceChange(
 function envVarObject(envs: string[]): Object {
   let map = new Map()
   envs.forEach((e) => {
-    let env = e.trim()
-    let splitIndex = env.indexOf('=')
-    map.set(
-      env.substring(0, splitIndex).trim(),
-      env.substring(splitIndex + 1).trim()
-    )
+    if (e) {
+      let env = e.trim()
+      let splitIndex = env.indexOf('=')
+      if (splitIndex > 0) {
+        map.set(
+          env.substring(0, splitIndex).trim(),
+          env.substring(splitIndex + 1).trim()
+        )
+      }
+    }
   })
   return Object.fromEntries(map)
 }

--- a/src/preference-resolver.ts
+++ b/src/preference-resolver.ts
@@ -45,4 +45,45 @@ function envVarObject(envs: string[]): Object {
   return Object.fromEntries(map)
 }
 
-export { onPreferenceChange, envVarObject }
+function splitArgString(str: string): string[] {
+  let args = []
+  let start = 0
+  while (start < str.length) {
+    let nextSpace = str.indexOf(' ', start)
+    let nextSingleQuote = str.indexOf("'", start)
+    let nextDoubleQuote = str.indexOf('"', start)
+    if (nextSpace === -1) {
+      // No more spaces, add the rest of the string as an argument.
+      args.push(str.substring(start))
+      start = str.length
+    } else if (
+      (nextSingleQuote === -1 || nextSpace < nextSingleQuote) &&
+      (nextDoubleQuote === -1 || nextSpace < nextDoubleQuote)
+    ) {
+      // No quote marks in next chunk. Split at next space.
+      args.push(str.substring(start, nextSpace))
+      start = nextSpace + 1
+    } else if (
+      nextSingleQuote !== -1 &&
+      (nextDoubleQuote === -1 || nextSingleQuote < nextDoubleQuote) &&
+      (nextSpace === -1 || nextSingleQuote < nextSpace)
+    ) {
+      // Single quote before a space or double quote. Chop at next single quote.
+      let closingQuote = str.indexOf("'", nextSingleQuote + 1)
+      args.push(str.substring(start, closingQuote + 1))
+      start = closingQuote + 1
+    } else if (
+      nextDoubleQuote !== -1 &&
+      (nextSingleQuote === -1 || nextDoubleQuote < nextSingleQuote) &&
+      (nextSpace === -1 || nextDoubleQuote < nextSpace)
+    ) {
+      // Double quote before a space or single quote. Chop at next double quote.
+      let closingQuote = str.indexOf('"', nextDoubleQuote + 1)
+      args.push(str.substring(start, closingQuote + 1))
+      start = closingQuote + 1
+    }
+  }
+  return args
+}
+
+export { onPreferenceChange, envVarObject, splitArgString }

--- a/src/rust-lang-server.ts
+++ b/src/rust-lang-server.ts
@@ -1,4 +1,8 @@
-import { envVarObject, onPreferenceChange } from './preference-resolver'
+import {
+  envVarObject,
+  onPreferenceChange,
+  splitArgString,
+} from './preference-resolver'
 
 export class RustLanguageServer {
   private languageClient: LanguageClient | null = null
@@ -21,7 +25,7 @@ export class RustLanguageServer {
       false,
       (lintArgs: string | null) => {
         if (lintArgs) {
-          this.lintArgs = lintArgs.split(' ')
+          this.lintArgs = splitArgString(lintArgs)
           this.restart()
         }
       }

--- a/src/rust-lang-server.ts
+++ b/src/rust-lang-server.ts
@@ -1,10 +1,11 @@
-import { onPreferenceChange } from './preference-resolver'
+import { envVarObject, onPreferenceChange } from './preference-resolver'
 
 export class RustLanguageServer {
   private languageClient: LanguageClient | null = null
   private crashAlert: Disposable | null = null
   private lintCommand = 'check'
   private lintArgs: string[] = []
+  private envVars: Object = {}
 
   constructor() {
     onPreferenceChange(
@@ -25,6 +26,10 @@ export class RustLanguageServer {
         }
       }
     )
+    onPreferenceChange('com.kilb.rust.env-vars', true, (varList: string[]) => {
+      this.envVars = envVarObject(varList)
+      this.restart()
+    })
   }
 
   get client(): LanguageClient | null {
@@ -87,6 +92,9 @@ export class RustLanguageServer {
       // The set of document syntaxes for which the server is valid
       syntaxes: ['rust'],
       initializationOptions: {
+        cargo: {
+          extraEnv: this.envVars,
+        },
         checkOnSave: {
           command: this.lintCommand,
           extraArgs: this.lintArgs,


### PR DESCRIPTION
Add a task template to the extension where users can more easily add Cargo commands. Adds simple cargo build/run/clean by default, and allows some customization. As part of this feature, a new extension preference collects environment variables to pass to both the task template AND Rust Analyzer.