### PR TITLE
Fix null method call blocking install

### DIFF
--- a/src/preference-resolver.ts
+++ b/src/preference-resolver.ts
@@ -30,7 +30,7 @@ function onPreferenceChange(
 // an object that can be given to processes.
 function envVarObject(envs: string[]): Object {
   let map = new Map()
-  envs.forEach((e) => {
+  envs?.forEach((e) => {
     if (e) {
       let env = e.trim()
       let splitIndex = env.indexOf('=')


### PR DESCRIPTION
Just updated to check out the latest update, but I immediately ran into a wall on clean install:

<img width="1359" alt="Screen Shot 2022-10-17 at 12 37 49 AM" src="https://user-images.githubusercontent.com/39429628/196098455-c00a397f-a6cb-461a-bf96-712474e20bc2.png">

Added a single `?`, reload, and...

<img width="1359" alt="Screen Shot 2022-10-17 at 12 39 38 AM" src="https://user-images.githubusercontent.com/39429628/196098458-0a5cfd5f-0b27-4388-ac78-bb54d10987d2.png">

good to go!

Something, something, rewrite it in Rust 🦀

Also, I've been using a barebones, unpublished fork of this extension for sometime which finds and uses a rustup installed RA component in either nightly or stable (now that it's available on stable) according to whichever toolchain I use on a per-project basis. Would be happy to put together another PR if you're interested in adding something along those lines.