### PR TITLE
Add Support for Tree Sitter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,8 @@ node_modules
 
 Rust.novaextension/Scripts
 Rust.novaextension/bin/rust-analyzer
+Rust.novaextension/Syntaxes/libtree-sitter-rust.dylib
+
+tree-sitter/build
+
 coverage

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tree-sitter/tree-sitter-rust"]
+	path = tree-sitter/tree-sitter-rust
+	url = https://github.com/tree-sitter/tree-sitter-rust

--- a/README.md
+++ b/README.md
@@ -10,28 +10,43 @@ Nova users can install this extension from Nova's [Extension Library](https://ex
 
 ### Requirements
 
-To help develop this extension, you'll need the Nova app, of course.
-
-To build the scripts for this extension, you will need [Node](https://nodejs.org/) installed (and the npm package manager that comes with it).
+- The Nova app, of course.
+- [Node](https://nodejs.org/) (and the **npm** package manager that comes with it): to build the scripts for this extension
+- **XCode**: to build the Tree Sitter library (Command Line Tools from Apple may suffice)
 
 ### Setting Up the Dev Environment
 
+This project depends on the `tree-sitter-rust` project, so you'll need to pull down the submodule when you clone or after cloning:
+
+```shell
+git clone --recurse-submodules https://github.com/kilbd/nova-rust
+# OR after cloning you can run
+git submodule update --init --recursive
+```
+
 Start by running the `update_server.sh` script to download the Rust Analyzer binary, then rename it manually:
 
-```bash
-$ cd Rust.novaextension/bin/
-$ ./update_server.sh
-$ mv rust-analyzer-new rust-analyzer
-$ cd ../..
+```shell
+cd Rust.novaextension/bin/
+./update_server.sh
+mv rust-analyzer-new rust-analyzer
+cd ../..
 ```
 
 This is done for users automatically, but in Nova's Developer Mode for extensions any file change triggers a reload of the extension, and thus you'd get stuck in an endless loop. In Dev Mode, I have the extension skip attempts to update Rust Analyzer.
 
+While you're running scripts, you might as well build the Tree Sitter library used for syntax highlighting and symbols. Then move the library to the `Syntaxes` folder. From the project root, run:
+
+```shell
+./tree-sitter/compile_parser.sh "$(pwd)/tree-sitter/tree-sitter-rust" /Applications/Nova.app
+mv ./tree-sitter/libtree-sitter-rust.dylib ./Rust.novaextension/Syntaxes/libtree-sitter-rust.dylib
+```
+
 Now you can install dependencies and build the scripts:
 
-```bash
-$ npm install
-$ npm run build
+```shell
+npm install
+npm run build
 ```
 
 After the scripts are transpiled, you can test the extension in Nova by selecting **Extensions -> Activate Project as Extension**. Open a Rust project to see it in action. You can monitor logs and errors by selecting **Extensions -> Show Extension Console** from the menus in the Rust project.

--- a/Rust.novaextension/CHANGELOG.md
+++ b/Rust.novaextension/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Version 2.3.0
+
+### New
+
+- Support for Tree Sitter language parsing introduced in Nova 10
+
 ## Version 2.2.1
 
 ### Fixed

--- a/Rust.novaextension/Queries/highlights.scm
+++ b/Rust.novaextension/Queries/highlights.scm
@@ -154,7 +154,7 @@
 (escape_sequence) @string.escape
 
 (attribute_item) @processing.attribute
-(attr_item
+(attribute
   arguments: (token_tree (string_literal) @processing.attribute))
 (inner_attribute_item) @processing.attribute
 

--- a/Rust.novaextension/Queries/highlights.scm
+++ b/Rust.novaextension/Queries/highlights.scm
@@ -1,0 +1,164 @@
+; Identifier conventions
+
+; Assume all-caps names are constants
+((identifier) @identifier.constant
+ (#match? @identifier.constant "^[A-Z][A-Z\\d_]+$'"))
+
+; Assume that uppercase names in paths are types
+((scoped_identifier
+  path: (identifier) @identifier.type)
+ (#match? @identifier.type "^[A-Z]"))
+((scoped_identifier
+  path: (scoped_identifier
+    name: (identifier) @identifier.type))
+ (#match? @identifier.type "^[A-Z]"))
+((scoped_type_identifier
+  path: (identifier) @identifier.type)
+ (#match? @identifier.type "^[A-Z]"))
+((scoped_type_identifier
+  path: (scoped_identifier
+    name: (identifier) @identifier.type))
+ (#match? @identifier.type "^[A-Z]"))
+
+; Assume other uppercase names are enum constructors
+((identifier) @identifier.type.enum
+ (#match? @identifier.type.enum "^[A-Z]"))
+
+; Assume all qualified names in struct patterns are enum constructors. (They're
+; either that, or struct names; highlighting both as constructors seems to be
+; the less glaring choice of error, visually.)
+(struct_pattern
+  type: (scoped_type_identifier
+    name: (type_identifier) @identifier.type.enum))
+
+; Function calls
+
+(call_expression
+  function: (identifier) @identifier.function
+  ; Identifiers starting with capital letters are likely enum constructors
+  (#not-match? @identifier.function "^[A-Z]"))
+(call_expression
+  function: (field_expression
+    field: (field_identifier) @identifier.method))
+(call_expression
+  function: (scoped_identifier
+    "::"
+    name: (identifier) @identifier.function)
+    ; Identifiers starting with capital letters are likely enum constructors
+    (#not-match? @identifier.function "^[A-Z]"))
+
+(generic_function
+  function: (identifier) @identifier.function)
+(generic_function
+  function: (scoped_identifier
+    name: (identifier) @identifier.function))
+(generic_function
+  function: (field_expression
+    field: (field_identifier) @identifier.method))
+
+(macro_invocation
+  macro: (identifier) @identifier.function.macro.markup.bold
+  "!" @identifier.function.macro.markup.bold)
+
+; Function definitions
+
+(function_item (identifier) @definition.function)
+(function_signature_item (identifier) @function)
+
+; Other identifiers
+
+(type_identifier) @identifier.type
+(primitive_type) @identifier.core.type.builtin
+(field_identifier) @identifier.property
+
+((line_comment) @comment.doc.string 
+  (#match? @comment.doc.string "^//[/!]"))
+(line_comment) @comment
+(block_comment) @comment
+
+"(" @punctuation.bracket
+")" @punctuation.bracket
+"[" @punctuation.bracket
+"]" @punctuation.bracket
+"{" @punctuation.bracket
+"}" @punctuation.bracket
+
+(type_arguments
+  "<" @punctuation.bracket
+  ">" @punctuation.bracket)
+(type_parameters
+  "<" @punctuation.bracket
+  ">" @punctuation.bracket)
+
+"::" @punctuation.delimiter
+":" @punctuation.delimiter
+"." @punctuation.delimiter
+"," @punctuation.delimiter
+";" @punctuation.delimiter
+
+(parameter (identifier) @identifier.argument)
+
+(lifetime (identifier) @identifier.decorator.lifetime)
+
+"as" @keyword
+"async" @keyword.modifier
+"await" @keyword
+"break" @keyword
+"const" @keyword
+"continue" @keyword
+"default" @keyword
+"dyn" @keyword
+"else" @keyword
+"enum" @keyword
+"extern" @keyword
+"fn" @keyword
+"for" @keyword
+"if" @keyword
+"impl" @keyword
+"in" @keyword
+"let" @keyword
+"loop" @keyword
+"macro_rules!" @keyword
+"match" @keyword
+"mod" @keyword
+"move" @keyword
+"pub" @keyword.modifier
+"ref" @keyword
+"return" @keyword
+"static" @keyword
+"struct" @keyword
+"trait" @keyword
+"type" @keyword
+"union" @keyword
+"unsafe" @keyword
+"use" @keyword
+"where" @keyword
+"while" @keyword
+(crate) @keyword
+(mutable_specifier) @keyword.modifier
+(use_list (self) @keyword)
+(scoped_use_list (self) @keyword)
+(scoped_identifier (self) @keyword.self)
+(super) @keyword
+
+(self) @keyword.self
+
+(char_literal) @string
+(string_literal) @string
+(raw_string_literal) @string
+
+(boolean_literal) @value.boolean
+(integer_literal) @value.number
+(float_literal) @value.number
+
+(escape_sequence) @string.escape
+
+(attribute_item) @processing.attribute
+(attr_item
+  arguments: (token_tree (string_literal) @processing.attribute))
+(inner_attribute_item) @processing.attribute
+
+"*" @operator
+"&" @operator
+"'" @operator
+"?" @operator

--- a/Rust.novaextension/Queries/injections.scm
+++ b/Rust.novaextension/Queries/injections.scm
@@ -1,0 +1,9 @@
+((macro_invocation
+  (token_tree) @injection.content)
+ (#set! injection.language "rust")
+ (#set! injection.include-children))
+
+((macro_rule
+  (token_tree) @injection.content)
+ (#set! injection.language "rust")
+ (#set! injection.include-children))

--- a/Rust.novaextension/Queries/symbols/impl_item.scm
+++ b/Rust.novaextension/Queries/symbols/impl_item.scm
@@ -1,0 +1,7 @@
+
+((impl_item
+    type: (type_identifier) @result)
+(#append! @result ": "))
+
+(impl_item
+    trait: (type_identifier) @result)

--- a/Rust.novaextension/Queries/symbols/impl_item.scm
+++ b/Rust.novaextension/Queries/symbols/impl_item.scm
@@ -1,7 +1,3 @@
-
 ((impl_item
     type: (type_identifier) @result)
-(#append! @result ": "))
-
-(impl_item
-    trait: (type_identifier) @result)
+(#append! @result " methods"))

--- a/Rust.novaextension/Queries/symbols/impl_trait_display.scm
+++ b/Rust.novaextension/Queries/symbols/impl_trait_display.scm
@@ -1,0 +1,13 @@
+
+((impl_item
+    type: (type_identifier) @result)
+(#prefix! @result " (")
+(#append! @result ")"))
+
+((impl_item
+    trait: (type_identifier) @result)
+(#append! @result " trait"))
+
+((impl_item
+    trait: (generic_type) @result)
+(#append! @result " trait"))

--- a/Rust.novaextension/Queries/symbols/impl_trait_name.scm
+++ b/Rust.novaextension/Queries/symbols/impl_trait_name.scm
@@ -1,0 +1,2 @@
+((impl_item
+    type: (type_identifier) @result))

--- a/Rust.novaextension/Queries/symbols/symbols.scm
+++ b/Rust.novaextension/Queries/symbols/symbols.scm
@@ -1,0 +1,47 @@
+; STRUCTS
+((struct_item 
+    name: (type_identifier) @name) @subtree
+(#set! role struct))
+
+; Struct fields
+((struct_item
+    body: (field_declaration_list
+        (field_declaration
+            name: (field_identifier) @name) @subtree))
+(#set! role property))
+
+; ENUMS
+((enum_item
+    name: (type_identifier) @name) @subtree
+(#set! role enum))
+
+((enum_item
+    body: (enum_variant_list
+    (enum_variant
+        name: (identifier) @name) @subtree))
+(#set! role enum-member))
+
+; Methods
+((impl_item
+    type: (type_identifier) @name @displayname
+    !trait) @subtree
+(#set! role category)
+(#append! @displayname " methods"))
+
+((impl_item
+    trait: (_)) @displayname.target @subtree
+(#set! role category)
+(#set! displayname.query "symbols/impl_item.scm"))
+
+
+
+; ((impl_item
+;     body: (declaration_list
+;         (function_item
+;             name: (identifier) @name) @subtree))
+; (#set! role method))
+
+; FUNCTIONS
+((function_item
+    name: (identifier) @name) @subtree
+(#set! role function-or-method))

--- a/Rust.novaextension/Queries/symbols/symbols.scm
+++ b/Rust.novaextension/Queries/symbols/symbols.scm
@@ -21,6 +21,16 @@
         name: (identifier) @name) @subtree))
 (#set! role enum-member))
 
+; Traits
+((trait_item
+    name: (type_identifier) @name) @subtree
+(#set! role interface))
+
+; Type
+((type_item
+    name: (type_identifier) @name) @subtree
+(#set! role type))
+
 ; Methods
 ((impl_item
     type: (type_identifier) @name
@@ -44,3 +54,8 @@
 ((function_item
     name: (identifier) @name) @subtree
 (#set! role function-or-method))
+
+; Modules - mostly useful for bundling test functions
+((mod_item
+    name: (identifier) @name) @subtree
+(#set! role package))

--- a/Rust.novaextension/Queries/symbols/symbols.scm
+++ b/Rust.novaextension/Queries/symbols/symbols.scm
@@ -23,17 +23,16 @@
 
 ; Methods
 ((impl_item
-    type: (type_identifier) @name @displayname
-    !trait) @subtree
-(#set! role category)
-(#append! @displayname " methods"))
-
-((impl_item
-    trait: (_)) @displayname.target @subtree
+    type: (type_identifier) @name
+    !trait) @subtree @displayname.target
 (#set! role category)
 (#set! displayname.query "symbols/impl_item.scm"))
 
-
+((impl_item
+    trait: (_)) @name.target @displayname.target @subtree
+(#set! role category)
+(#set! name.query "symbols/impl_trait_name.scm")
+(#set! displayname.query "symbols/impl_trait_display.scm"))
 
 ; ((impl_item
 ;     body: (declaration_list

--- a/Rust.novaextension/Queries/textChecking.scm
+++ b/Rust.novaextension/Queries/textChecking.scm
@@ -1,0 +1,7 @@
+(string_literal) @subtree
+
+(raw_string_literal) @subtree
+
+(line_comment) @subtree
+
+(block_comment) @subtree

--- a/Rust.novaextension/Syntaxes/Rust.xml
+++ b/Rust.novaextension/Syntaxes/Rust.xml
@@ -12,6 +12,7 @@
   
   <tree-sitter>
     <highlights />
+    <symbols path="symbols/symbols.scm" />
   </tree-sitter>
   
   <indentation>

--- a/Rust.novaextension/Syntaxes/Rust.xml
+++ b/Rust.novaextension/Syntaxes/Rust.xml
@@ -10,6 +10,10 @@
     <extension priority="1.0">rs</extension>
   </detectors>
   
+  <tree-sitter>
+    <highlights />
+  </tree-sitter>
+  
   <indentation>
     <increase>
       <expression>(\{[^}\"']*$)|(\[[^\]\"']*$)|(\([^)\"']*$)</expression>

--- a/Rust.novaextension/Syntaxes/Rust.xml
+++ b/Rust.novaextension/Syntaxes/Rust.xml
@@ -13,6 +13,7 @@
   <tree-sitter>
     <highlights />
     <symbols path="symbols/symbols.scm" />
+    <text-checking />
   </tree-sitter>
   
   <indentation>

--- a/Rust.novaextension/extension.json
+++ b/Rust.novaextension/extension.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/kilbd/nova-rust",
   "bugs": "https://github.com/kilbd/nova-rust/issues",
   "license": "MIT",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "categories": ["languages", "formatters"],
   "min_runtime": "9.0",
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nova-rust",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "private": true,
   "author": "Drew Kilb",
   "scripts": {

--- a/tree-sitter/Makefile
+++ b/tree-sitter/Makefile
@@ -1,0 +1,64 @@
+# PARSER_SRC should be passed into `make`
+PARSER_SRC ?= .
+SRC_DIR := $(PARSER_SRC)/src
+
+PARSER_NAME ?= $(shell basename $(PARSER_SRC) | cut -d '-' -f3)
+UPPER_PARSER_NAME := $(shell echo $(PARSER_NAME) | tr a-z A-Z )
+
+# install directory layout
+PREFIX ?= /usr/local
+INCLUDEDIR ?= $(PREFIX)/include
+LIBDIR ?= $(PREFIX)/lib
+
+# collect sources, and link if necessary
+# Some Tree Sitter grammars include .cc files directly in others,
+# so we shouldn't just wildcard select them all.
+# Only collect known file names.
+ifneq ("$(wildcard $(SRC_DIR)/parser.c)", "")
+	SRC += $(SRC_DIR)/parser.c
+endif
+ifneq ("$(wildcard $(SRC_DIR)/scanner.c)", "")
+	SRC += $(SRC_DIR)/scanner.c
+endif
+ifneq ("$(wildcard $(SRC_DIR)/parser.cc)", "")
+    CPPSRC += $(SRC_DIR)/parser.cc
+endif
+ifneq ("$(wildcard $(SRC_DIR)/scanner.cc)", "")
+    CPPSRC += $(SRC_DIR)/scanner.cc
+endif
+
+ifeq (, $(CPPSRC))
+	ADDITIONALLIBS := 
+else
+	ADDITIONALLIBS := -lc++
+endif
+
+SRC += $(CPPSRC)
+OBJ := $(addsuffix .o,$(basename $(SRC)))
+
+CFLAGS ?= -O3 -Wall -Wextra -I$(SRC_DIR)
+CXXFLAGS ?= -O3 -Wall -Wextra -I$(SRC_DIR)
+override CFLAGS += -std=gnu99 -fPIC
+override CXXFLAGS += -fPIC
+
+LINKSHARED := $(LINKSHARED)-dynamiclib -Wl,
+ifneq ($(ADDITIONALLIBS),)
+  LINKSHARED := $(LINKSHARED)$(ADDITIONALLIBS),
+endif
+LINKSHARED := $(LINKSHARED)-install_name,$(LIBDIR)/libtree-sitter-$(PARSER_NAME).dylib,-rpath,@executable_path/../Frameworks
+
+all: libtree-sitter-$(PARSER_NAME).dylib
+
+libtree-sitter-$(PARSER_NAME).dylib: $(OBJ)
+	$(CC) $(LDFLAGS) $(LINKSHARED) $^ $(LDLIBS) -o $@
+
+install: all
+	install -d '$(DESTDIR)$(LIBDIR)'
+	install -m755 libtree-sitter-$(PARSER_NAME).dylib '$(DESTDIR)$(LIBDIR)'/libtree-sitter-$(PARSER_NAME).dylib
+	install -d '$(DESTDIR)$(INCLUDEDIR)'/tree_sitter
+
+clean:
+	rm -f $(OBJ) libtree-sitter-$(PARSER_NAME).dylib
+	rm -rf build/
+
+.PHONY: all install clean

--- a/tree-sitter/compile_parser.sh
+++ b/tree-sitter/compile_parser.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -euxo pipefail
+
+# Assume Makefile sits in BASEDIR above parser source files
+PARSER_SRC=$1
+BASEDIR=$(dirname "$PARSER_SRC")
+APPBUNDLE=$2
+FRAMEWORKS_PATH="${APPBUNDLE}/Contents/Frameworks/"
+# Create build files next to this script
+WORKINGDIR=$(cd "$(dirname "$0")"; pwd -P)
+
+# - Build both arm64 (Apple Silicon) and x86_64 (Intel)
+# - Require a minimum of macOS 11.0
+# - Include the /src/ directory for headers (for `tree_sitter/parser.h`)
+BUILD_FLAGS="-arch arm64 -arch x86_64 -mmacosx-version-min=11.0 -I${PARSER_SRC}/src/"
+
+# Build in a temporary `build/` directory.
+TMP_BUILD_DIR=$WORKINGDIR/build
+mkdir -p "$TMP_BUILD_DIR"
+
+pushd "$BASEDIR"
+
+CFLAGS="${BUILD_FLAGS} -O3" \
+CXXFLAGS="${BUILD_FLAGS} -O3" \
+LDFLAGS="${BUILD_FLAGS} -F${FRAMEWORKS_PATH} -framework SyntaxKit -rpath @loader_path/../Frameworks" \
+PARSER_SRC="$PARSER_SRC" \
+PREFIX="$TMP_BUILD_DIR" make install
+
+popd


### PR DESCRIPTION
Tree Sitter support was added in Nova 10. Supporting it with this Rust extension should result in improved syntax highlighting.