### PR TITLE
Update @types/nova-editor-node to 5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "nova-rust",
-  "version": "2.1.0",
+  "version": "2.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nova-rust",
-      "version": "2.1.0",
+      "version": "2.3.2",
       "devDependencies": {
         "@types/jest": "^27.0.2",
-        "@types/nova-editor-node": "^4.1.5",
+        "@types/nova-editor-node": "^5.1.0",
         "jest": "^27.2.2",
         "prettier": "^2.4.1",
         "ts-jest": "^27.0.5",
@@ -985,9 +985,9 @@
       "dev": true
     },
     "node_modules/@types/nova-editor-node": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@types/nova-editor-node/-/nova-editor-node-4.1.5.tgz",
-      "integrity": "sha512-oq3Bobk00wmy4ahoDEcICGUzLxw8eaUN7Th0xNyH2wFl6eL6S9ZX+I09t2Y4ZYKEiztiDwf0TM1r12zkigyKRw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@types/nova-editor-node/-/nova-editor-node-5.1.0.tgz",
+      "integrity": "sha512-Jj8wnUGOYmmNgd61JHSG0kV5o/zlthVn92qCdLz6VYa7CM4KSmwPjCeCzw2JqjJw6QONpcMXTVH9TKtLCnFf1Q==",
       "dev": true
     },
     "node_modules/@types/prettier": {
@@ -4853,9 +4853,9 @@
       "dev": true
     },
     "@types/nova-editor-node": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@types/nova-editor-node/-/nova-editor-node-4.1.5.tgz",
-      "integrity": "sha512-oq3Bobk00wmy4ahoDEcICGUzLxw8eaUN7Th0xNyH2wFl6eL6S9ZX+I09t2Y4ZYKEiztiDwf0TM1r12zkigyKRw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@types/nova-editor-node/-/nova-editor-node-5.1.0.tgz",
+      "integrity": "sha512-Jj8wnUGOYmmNgd61JHSG0kV5o/zlthVn92qCdLz6VYa7CM4KSmwPjCeCzw2JqjJw6QONpcMXTVH9TKtLCnFf1Q==",
       "dev": true
     },
     "@types/prettier": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@types/jest": "^27.0.2",
-    "@types/nova-editor-node": "^4.1.5",
+    "@types/nova-editor-node": "^5.1.0",
     "jest": "^27.2.2",
     "prettier": "^2.4.1",
     "ts-jest": "^27.0.5",


### PR DESCRIPTION
This fixes typo and adds some missing parameters used in this codebase.

* When calling `registerTaskAssistant`, `identifier` can now be spelled correctly (instead of `identifer`).
* `TaskProcessAction` now has a `shell` parameter
* `TaskActionResolveContext` now has a `config` property.

More info in the updates to @types/nova-editor-node:

* https://github.com/DefinitelyTyped/DefinitelyTyped/pull/65616
* https://github.com/DefinitelyTyped/DefinitelyTyped/pull/65630

---

Note: I don't use conventional commits much. I picked `chore` because it has zero effect on users of the extension. Happy to change if you think it needs to be `fix` or something else.